### PR TITLE
10.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dibk-design",
-	"version": "10.5.8",
+	"version": "10.5.9",
 	"homepage": "https://Ojself.github.io/dibk-design",
 	"main": "dist/index.cjs.js",
 	"module": "dist/index.es.js",

--- a/src/components/InfoBox.module.scss
+++ b/src/components/InfoBox.module.scss
@@ -68,7 +68,7 @@
 .inner {
   display: grid;
   gap: 12px;
-  
+  align-items: start;
   grid-template-columns: 1fr;
   padding: 20px;
 

--- a/src/components/NavigationBar.module.scss
+++ b/src/components/NavigationBar.module.scss
@@ -19,6 +19,11 @@
     max-width: 1600px;
     gap: 10px;
     margin: 0 auto;
+
+    @media only screen and (min-width: viewports.$screen-sm) and (max-width: viewports.$screen-lg - 1px) {
+        padding-left: 24px;
+        padding-right: 24px;
+    }
         position: relative;
         .navigationBar {
             position: relative;

--- a/src/components/Tabs.module.scss
+++ b/src/components/Tabs.module.scss
@@ -25,7 +25,9 @@
   align-items: center;
   line-height: 30px;
   gap: 8px;
-  padding: 20px 30px 17px 30px;
+  height: 67px;
+  padding: 0 30px;
+  white-space: nowrap;
   margin: 0;
   background-color: transparent;
   border: none;
@@ -75,7 +77,7 @@
 }
 
 .tabLabel {
-  line-height: 30px;
+  line-height: normal;
 }
 
 .tabAmount {


### PR DESCRIPTION
- InfoBox: align grid items to start to prevent vertical stretching
- NavigationBar: add horizontal padding on tablet-sized screens (sm–lg)
- Tabs: use fixed height and nowrap on tab items for consistent sizing